### PR TITLE
Complete Missing Workflows for Issue #5

### DIFF
--- a/templates/ci-templates/github/python/ci-poetry-lock-validation/validate-setuptools-lock.yml
+++ b/templates/ci-templates/github/python/ci-poetry-lock-validation/validate-setuptools-lock.yml
@@ -1,0 +1,41 @@
+# Github Actions Workflow: Validate requirements.txt is up-to-date with lock files.
+
+name: Validate Setuptools Lock
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.py'  # Trigger on Python file changes
+      - 'requirements.in'  # Trigger on input dependency file changes
+      - 'requirements.txt'  # Trigger on lock file changes
+      - '.github/workflows/validate-setuptools-lock.yml'  # Trigger on workflow file changes
+  pull_request:
+    paths:
+      - '**.py'
+      - 'requirements.in'
+      - 'requirements.txt'
+      - '.github/workflows/validate-setuptools-lock.yml'
+
+jobs:
+  validate-setuptools-lock:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout repository code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Set up Python environment
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # Install pip-tools for dependency locking
+      - name: Install pip-tools
+        run: pip install pip-tools
+
+      # Validate that requirements.txt is in sync with requirements.in
+      - name: Validate setuptools lock file
+        run: pip-compile --check

--- a/templates/ci-templates/github/python/ci-publish/publish-pypi.yml
+++ b/templates/ci-templates/github/python/ci-publish/publish-pypi.yml
@@ -1,0 +1,47 @@
+# Github Actions Workflow: Publish package to PyPI on release.
+
+name: Publish Python Package to PyPI
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags (e.g., v1.0.0)
+    paths:
+      - '**.py'                           # Trigger on Python file changes
+      - '.github/workflows/publish-pypi.yml'  # Trigger on workflow file changes
+  pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/publish-pypi.yml'
+
+jobs:
+  publish-pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout repository code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Set up Python environment
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # Install build tools
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip setuptools wheel twine
+
+      # Build Python package using setuptools
+      - name: Build package (setuptools)
+        run: |
+          python -m build
+
+      # Publish package to PyPI using Twine
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m twine upload dist/*

--- a/templates/ci-templates/github/python/ci-publish/publish-testpypi.yml
+++ b/templates/ci-templates/github/python/ci-publish/publish-testpypi.yml
@@ -1,0 +1,47 @@
+# Github Actions Workflow: Publish to TestPyPI for dry runs.
+
+name: Publish Python Package to TestPyPI
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags (e.g., v1.0.0)
+    paths:
+      - '**.py'                           # Trigger on Python file changes
+      - '.github/workflows/publish-testpypi.yml'  # Trigger on workflow file changes
+  pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/publish-testpypi.yml'
+
+jobs:
+  publish-testpypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout repository code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Set up Python environment
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # Install build tools
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip setuptools wheel twine
+
+      # Build Python package using setuptools
+      - name: Build package (setuptools)
+        run: |
+          python -m build
+
+      # Publish package to TestPyPI using Twine
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.TESTPYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TESTPYPI_PASSWORD }}
+        run: |
+          python -m twine upload --repository testpypi dist/*


### PR DESCRIPTION
# 🔧 Complete Missing Workflows for Issue #5

This PR adds the remaining GitHub Actions workflows that were initially skipped in issue #5:

-  `Publish-testpypi.yml`
-  `Publish-pypi.yml`
-  `Validate-setuptools-lock.yml`

These complete the previously unaddressed parts of the CI/CD pipeline.

---

 Follow-up to finalize issue #5.
