### PR TITLE
feat: #30 allow multiple downloads

### DIFF
--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -14,19 +14,74 @@ const GITHUB_RAW_BASE: &str =
 const GITHUB_API_BASE: &str =
     "https://api.github.com/repos/rafaeljohn9/gh-templates/contents/templates";
 
-pub fn add(template: &str, _extra_args: &[String]) -> anyhow::Result<()> {
+pub fn add(args: &[String]) -> anyhow::Result<()> {
     let fetcher = Fetcher::new();
-    let url = format!("{}/issue-templates/{}.yml", GITHUB_RAW_BASE, template);
-    let dest_path = Path::new(OUTPUT_BASE_PATH)
-        .join(OUTPUT)
-        .join(format!("{}.yml", template));
 
-    fetcher.fetch_to_file(&url, &dest_path)?;
+    if args.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No issue template specified. Use --all to download all templates."
+        ));
+    }
 
-    println!(
-        "\x1b[32m✓\x1b[0m Downloaded and added issue template: {}",
-        dest_path.display()
-    );
+    // Check if --all flag is provided
+    if args.contains(&"--all".to_string()) {
+        let pb = ProgressBar::new_spinner();
+        pb.set_style(
+            ProgressStyle::default_spinner()
+                .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"])
+                .template("{spinner} {msg}")
+                .unwrap(),
+        );
+        pb.enable_steady_tick(Duration::from_millis(100));
+        pb.set_message("Fetching all templates...");
+
+        let url = format!("{}/issue-templates", GITHUB_API_BASE);
+        let entries = fetcher.fetch_json(&url)?;
+        let mut downloaded_templates = Vec::new();
+
+        if let Some(array) = entries.as_array() {
+            for entry in array {
+                if let Some(name) = entry.get("name").and_then(|n| n.as_str()) {
+                    let template_name = match name.rfind('.') {
+                        Some(idx) => &name[..idx],
+                        None => name,
+                    };
+
+                    pb.set_message(format!("Downloading template: {}", template_name));
+
+                    let url = format!("{}/issue-templates/{}", GITHUB_RAW_BASE, name);
+                    let dest_path = Path::new(OUTPUT_BASE_PATH).join(OUTPUT).join(name);
+
+                    fetcher.fetch_to_file(&url, &dest_path)?;
+                    downloaded_templates.push(format!("{}.yml", template_name));
+                }
+            }
+        }
+        pb.finish_and_clear();
+        println!(
+            "\x1b[32m✓\x1b[0m Downloaded all issue templates to {}/{}",
+            OUTPUT_BASE_PATH, OUTPUT
+        );
+        for template in downloaded_templates {
+            println!("  \x1b[32m>\x1b[0m {}", template);
+        }
+    } else {
+        // Download specified templates
+        for template in args {
+            let url = format!("{}/issue-templates/{}.yml", GITHUB_RAW_BASE, template);
+            let dest_path = Path::new(OUTPUT_BASE_PATH)
+                .join(OUTPUT)
+                .join(format!("{}.yml", template));
+
+            fetcher.fetch_to_file(&url, &dest_path)?;
+
+            println!(
+                "\x1b[32m✓\x1b[0m Downloaded and added issue template: {}",
+                dest_path.display()
+            );
+        }
+    }
+
     Ok(())
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,10 +1,10 @@
 pub mod issue;
 pub mod license;
 
-pub fn dispatch_add(category: &str, template: &str, extra_args: &[String]) -> anyhow::Result<()> {
+pub fn dispatch_add(category: &str, args: &[String]) -> anyhow::Result<()> {
     match category {
-        "issue" => issue::add(template, extra_args),
-        "license" => license::add(template, extra_args),
+        "issue" => issue::add(args),
+        "license" => license::add(args),
         _ => Err(anyhow::anyhow!("Unknown category: {}", category)),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,9 @@ enum Commands {
     Add {
         /// Template category (e.g., issue, pr, ci, license, gitignore)
         category: String,
-        /// Template name (e.g., bug, feature-request)
-        template: String,
+        /// Template name(s) (e.g., bug, feature-request)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        extra_args: Vec<String>,
+        args: Vec<String>,
     },
 
     /// List available templates in a category
@@ -43,12 +42,8 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Add {
-            category,
-            template,
-            extra_args,
-        } => {
-            commands::dispatch_add(&category, &template, &extra_args)?;
+        Commands::Add { category, args } => {
+            commands::dispatch_add(&category, &args)?;
         }
 
         Commands::List {


### PR DESCRIPTION
# Changes summary
 
- We can now download multiple templates either by specifying the name or using `--all`
- Refactored `add` cmd to have only the `args`  parameter: much cleaner approach to support multiple downloads