### PR TITLE
fix: correct type for 'steps' field in testing issue template

### DIFF
--- a/templates/issue-templates/test.yml
+++ b/templates/issue-templates/test.yml
@@ -35,7 +35,7 @@ body:
     validations:
       required: true
 
-  - type: textareahelp wanted
+  - type: textarea
     id: steps
     attributes:
       label: Steps to Reproduce


### PR DESCRIPTION
---
name: Pull Request
about:  bug fix
title: Fix invalid input type in Testing & QA issue form
labels: bug
---

## 🔗 Related Issue(s)
<!-- > Link to the relevant issue(s). Create one if it doesn't exist. -->

- Closes #91 

---

## Summary

This PR fixes a typo in the Testing & QA issue form where `textareahelp wanted` was used as an invalid input type. It is corrected to `textarea` to comply with GitHub issue forms specification.

## Testing

How was this change tested? List test cases, manual steps, or CI checks.

- [ ] Added/updated unit tests
- [x] Performed manual testing
- [ ] Validated with stakeholders
