### PR TITLE
Feature have compulsory fields to have an alternate of  no response  #63

### DIFF
--- a/templates/issue-templates/bug.yml
+++ b/templates/issue-templates/bug.yml
@@ -9,7 +9,7 @@ body:
     id: bug-category
     attributes:
       label: Bug Category
-      description: Please select the most appropriate category for this bug.
+      description: Please select the most appropriate category for this bug. If none apply, select "_No Response_"
       options:
         - Functional Issue (feature not working as intended)
         - Performance Issue (slow, unresponsive, resource usage)
@@ -18,6 +18,7 @@ body:
         - Build/Deployment Issue (installation, CI/CD, packaging)
         - Regression (previously working, now broken)
         - Other validations
+        - _No Response_
     validations:
       required: true
 
@@ -25,8 +26,8 @@ body:
     id: actual-behavior
     attributes:
       label: Actual Behavior
-      description: What actually happened?
-      placeholder: Describe what actually happened.
+      description: What actually happened? If not applicable, write "_No Response_".
+      placeholder: Describe what actually happened or type "_No Response_" if not applicable.
     validations:
       required: true
 
@@ -34,8 +35,8 @@ body:
     id: expected-behavior
     attributes:
       label: Expected Behavior
-      description: What did you expect to happen?
-      placeholder: Describe what you expected to see.
+      description: What did you expect to happen? If not applicable, write "_No Response_".
+      placeholder: Describe what you expected to see or type "_No Response_" if not applicable.
     validations:
       required: true
 
@@ -43,12 +44,13 @@ body:
     id: steps-to-reproduce
     attributes:
       label: Steps to Reproduce
-      description: List the steps to reproduce the behavior.
+      description: List the steps to reproduce the behavior. If not applicable, write "_No Response_".
       placeholder: |
         1. Go to '...'
         2. Click on '...'
         3. Scroll down to '...'
         4. See error
+        Or type "_No Response_" if this does not apply.
     validations:
       required: true
 

--- a/templates/issue-templates/community.yml
+++ b/templates/issue-templates/community.yml
@@ -19,13 +19,14 @@ body:
     id: subcategory
     attributes:
       label: Subcategory
-      description: Select the subcategory that best fits your issue or suggestion.
+      description: Select the subcategory that best fits your issue or suggestion. If none apply, select "_No Response_".
       options:
         - first-timers-only (Mentored, beginner-friendly)
         - contribution-guide (Missing or unclear steps)
         - labeling-feedback (Labels, issue templates, etc.)
         - moderation-issue (Toxic comment, off-topic, spam)
         - project-governance (Suggesting changes to rules or roadmap)
+        - _No Response_
     validations:
       required: true
 
@@ -33,8 +34,8 @@ body:
     id: description
     attributes:
       label: Description
-      description: Please describe your issue or suggestion in detail.
-      placeholder: Tell us what happened or what could be improved.
+      description: Please describe your issue or suggestion in detail. If not applicable, write "_No Response_".
+      placeholder: Tell us what happened or what could be improved or type "_No Response_" if not applicable.
     validations:
       required: true
 

--- a/templates/issue-templates/docs.yml
+++ b/templates/issue-templates/docs.yml
@@ -15,7 +15,7 @@ body:
     id: subcategory
     attributes:
       label: Subcategory
-      description: Select the most relevant subcategory for your issue.
+      description: Select the most relevant subcategory for your issue. If none apply, select "_No Response_".
       options:
         - missing-docs - Docs are completely absent
         - outdated-docs - Needs update to match current behavior
@@ -23,6 +23,7 @@ body:
         - new-docs-request - Suggesting a new section or tutorial
         - readme-improvement - Better structure or examples
         - api-docs-issue - Generated or manual API references
+        - _No Response_
     validations:
       required: true
 
@@ -30,8 +31,8 @@ body:
     id: description
     attributes:
       label: Description
-      description: Please describe the documentation issue or suggestion in detail.
-      placeholder: Tell us what needs to be fixed or improved.
+      description: Please describe the documentation issue or suggestion in detail. If not applicable, write "_No Response_".
+      placeholder: Tell us what needs to be fixed or improved or type "_No Response_" if not applicable.
     validations:
       required: true
 

--- a/templates/issue-templates/dx.yml
+++ b/templates/issue-templates/dx.yml
@@ -17,12 +17,13 @@ body:
     id: subcategory
     attributes:
       label: Subcategory
-      description: Select the area most affected
+      description: Select the area most affected. If none apply, select "_No Response_".
       options:
         - setup-complexity - Project is hard to set up
         - env-vars-issue - Missing .env or unclear config
         - onboarding-gap - New devs face barriers to contributing
         - cli-issue - Internal tool, CLI issue
+        - _No Response_
     validations:
       required: true
 
@@ -30,8 +31,8 @@ body:
     id: description
     attributes:
       label: Describe the issue
-      description: Please provide a clear and concise description of the problem.
-      placeholder: What happened? What did you expect?
+      description: Please provide a clear and concise description of the problem. If not applicable, write "_No Response_".
+      placeholder: What happened? What did you expect? If not applicable, type "_No Response_".
     validations:
       required: true
 

--- a/templates/issue-templates/feature.yml
+++ b/templates/issue-templates/feature.yml
@@ -18,7 +18,7 @@ body:
     id: subcategory
     attributes:
       label: Subcategory
-      description: Select the type of feature request
+      description: Select the type of feature request. If none apply, select "_No Response_".
       options:
         - new-feature - Entirely new functionality
         - feature-enhancement - Improving existing features
@@ -26,6 +26,7 @@ body:
         - accessibility-request - a11y features for users with disabilities
         - integration-request - Suggesting 3rd-party tool or API integration
         - configurability - Suggesting more options/settings
+        - _No Response_
     validations:
       required: true
 
@@ -33,8 +34,8 @@ body:
     id: description
     attributes:
       label: Description
-      description: Please describe the feature or improvement you are requesting.
-      placeholder: What problem does this solve? What would you like to see?
+      description: Please describe the feature or improvement you are requesting. If not applicable, write "_No Response_".
+      placeholder: What problem does this solve? What would you like to see? If not applicable, type "_No Response_".
     validations:
       required: true
 

--- a/templates/issue-templates/support.yml
+++ b/templates/issue-templates/support.yml
@@ -17,13 +17,14 @@ body:
     id: subcategory
     attributes:
       label: Subcategory
-      description: What type of support do you need?
+      description: What type of support do you need? If none apply, select "_No Response_".
       options:
         - how-to: User doesn’t know how to use feature
         - expected-behavior: Confused by what the app should do
         - support-needed: Setup or usage help
         - environment-help: Local dev env isn’t working
         - deprecated-feature-confusion: Unsure why something was removed
+        - _No Response_
       multiple: false
     validations:
       required: true
@@ -32,8 +33,8 @@ body:
     id: question
     attributes:
       label: Your Question
-      description: Please describe your question or the support you need in detail.
-      placeholder: "Describe your issue or question here..."
+      description: Please describe your question or the support you need in detail. If not applicable, write "_No Response_".
+      placeholder: "Describe your issue or question here...Or type _No Response_ if not applicable."
     validations:
       required: true
 

--- a/templates/issue-templates/test.yml
+++ b/templates/issue-templates/test.yml
@@ -17,12 +17,13 @@ body:
     id: subcategory
     attributes:
       label: Subcategory
-      description: Select the most relevant subcategory for your issue.
+      description: Select the most relevant subcategory for your issue. If none apply, select "_No Response_".
       options:
         - unit-test-failure - Unit test consistently fails
         - test-coverage - Request to add or improve tests
         - flaky-test - Test fails randomly
         - test-env-setup - Test environment config problem
+        - _No Response_
     validations:
       required: true
 
@@ -30,8 +31,8 @@ body:
     id: description
     attributes:
       label: Description
-      description: Please describe the issue in detail.
-      placeholder: Describe the problem, steps to reproduce, and any relevant logs or screenshots.
+      description: Please describe the issue in detail. If not applicable, write "_No Response_".
+      placeholder: Describe the problem, steps to reproduce, and any relevant logs or screenshots or type "_No Response_" if not applicable.
     validations:
       required: true
 


### PR DESCRIPTION
---
name: Pull Request
about: Have compulsory fields to have an alternate of  `_no response_`
title: "Add alternate of `_no response_` for compulsory fields"
labels: `enhancement`,`feature`,`feature-request`
---

## 🔗 Related Issue(s)
<!-- > Link to the relevant issue(s). Create one if it doesn't exist. -->

- Closes #63 

---

## Summary

> Briefly describe **what** this PR changes and **why**.

<!-- Example:
> Added input validation to the registration form to improve user experience and prevent invalid data submission. -->

Added _No Response_ option for compulsory fields to avoid redundancy

---

## Testing

How was this change tested? List test cases, manual steps, or CI checks.

- [ ] Added/updated unit tests
- [x] Performed manual testing
- [ ] Validated with stakeholders
