### PR TITLE
fix: remove color encodings inside string to use 'colored' lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "console"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +605,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "colored",
  "dirs",
  "indicatif",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ predicates = "3.1.3"
 tempfile = "3.20.0"
 regex = "1.11.1"
 serde_yaml = "0.9.34"
+colored = "3.0.0"
 
 [build-dependencies]
 regex = "1.11.1"

--- a/src/commands/gitignore/add.rs
+++ b/src/commands/gitignore/add.rs
@@ -1,5 +1,7 @@
-use anyhow::Result;
 use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use colored::*;
 
 use crate::utils::cache::{Cache, CacheManager};
 use crate::utils::file;
@@ -98,7 +100,8 @@ fn download_all_templates(
     }
 
     println!(
-        "\x1b[32m✓\x1b[0m Downloaded and merged all gitignore templates to {}",
+        "{} Downloaded and merged all gitignore templates to {}",
+        "✓".green(),
         dest_path.display()
     );
 
@@ -144,7 +147,8 @@ fn download_templates(
     }
 
     println!(
-        "\x1b[32m✓\x1b[0m Added gitignore templates: {}",
+        "{} Added gitignore templates: {}",
+        "✓".green(),
         templates.join(", ")
     );
 

--- a/src/commands/gitignore/list.rs
+++ b/src/commands/gitignore/list.rs
@@ -1,3 +1,4 @@
+use colored::*;
 use std::collections::HashMap;
 
 use crate::utils::cache::{Cache, CacheManager};
@@ -95,7 +96,7 @@ fn display_templates(templates: Vec<GitIgnoreTemplate>) {
         return;
     }
 
-    println!("\x1b[32m✓\x1b[0m Available gitignore templates:");
+    println!("{}", "✓ Available gitignore templates:".green());
 
     // Group by category for better display
     let mut by_category: HashMap<String, Vec<&GitIgnoreTemplate>> = HashMap::new();
@@ -109,11 +110,13 @@ fn display_templates(templates: Vec<GitIgnoreTemplate>) {
     for (category, mut templates) in by_category {
         templates.sort_by(|a, b| a.name.cmp(&b.name));
 
-        println!("\n\x1b[1m{}:\x1b[0m", category.to_uppercase());
+        println!("\n{}", category.to_uppercase().bold());
         for template in templates {
             println!(
-                "  \x1b[32m>\x1b[0m {:<20} ({})",
-                template.name, template.path
+                "  {} {:<20} ({})",
+                ">".green(),
+                template.name,
+                template.path
             );
         }
     }

--- a/src/commands/issue/add.rs
+++ b/src/commands/issue/add.rs
@@ -1,3 +1,4 @@
+use colored::*;
 use std::path::{Path, PathBuf};
 
 use crate::utils::file;
@@ -66,8 +67,10 @@ fn download_all_templates(dir_path: Option<&PathBuf>, force: bool) -> anyhow::Re
 
         if let Err(e) = download_single_template(template_name, dir_path, force) {
             eprintln!(
-                "\x1b[31m✗\x1b[0m Failed to add template '{}': {}",
-                template_name, e
+                "{} Failed to add template '{}': {}",
+                "✗".red(),
+                template_name,
+                e
             );
             errors.push((template_name.to_string(), e));
         }
@@ -80,11 +83,15 @@ fn download_all_templates(dir_path: Option<&PathBuf>, force: bool) -> anyhow::Re
 
     if errors.is_empty() {
         println!(
-            "\x1b[32m✓\x1b[0m Downloaded all issue templates to {}",
+            "{} Downloaded all issue templates to {}",
+            "✓".green(),
             output_location
         );
     } else {
-        println!("\x1b[33m⚠\x1b[0m Some templates failed to download. See errors above.");
+        println!(
+            "{} Some templates failed to download. See errors above.",
+            "⚠".yellow()
+        );
     }
 
     Ok(())
@@ -111,7 +118,7 @@ fn download_single_template(
 
     file::save_file(&content, &dest_path, force)?;
 
-    println!("\x1b[32m✓\x1b[0m Added template: {}", template_name);
+    println!("{} Added template: {}", "✓".green(), template_name);
 
     Ok(())
 }

--- a/src/commands/issue/list.rs
+++ b/src/commands/issue/list.rs
@@ -1,3 +1,5 @@
+use colored::*;
+
 use crate::utils::get_comment;
 use crate::utils::manifest_navigator::ManifestNavigator;
 use crate::utils::remote::Fetcher;
@@ -37,7 +39,8 @@ fn list_all_templates() -> anyhow::Result<()> {
         };
 
         println!(
-            "\x1b[32m> \x1b[0m {} - {}",
+            "{} {} - {}",
+            ">".green(),
             entry.name,
             comment.unwrap_or_default()
         );

--- a/src/commands/license/add.rs
+++ b/src/commands/license/add.rs
@@ -3,6 +3,7 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 
 use anyhow::{Result, anyhow};
+use colored::*;
 use regex::Regex;
 
 use crate::utils::cache::CacheManager;
@@ -91,7 +92,10 @@ impl super::Runnable for AddArgs {
         } else {
             for license_id in &self.licenses {
                 if let Err(e) = download_single_license(license_id, &config) {
-                    eprintln!("\x1b[31mFailed to download {}: {}\x1b[0m", license_id, e);
+                    eprintln!(
+                        "{}",
+                        format!("Failed to download {}: {}", license_id, e).red()
+                    );
                 }
             }
         }
@@ -165,7 +169,8 @@ fn download_single_license(id: &str, config: &LicenseDownloadConfig) -> Result<(
     file::save_file(&processed_text, &dest_path, config.force)?;
 
     println!(
-        "\x1b[32m✓\x1b[0m Downloaded and added license: {}",
+        "{} Downloaded and added license: {}",
+        "✓".green(),
         dest_path.display()
     );
 
@@ -208,7 +213,10 @@ fn download_all_licenses(config: &LicenseDownloadConfig) -> Result<()> {
             .ok_or_else(|| anyhow!("License ID not found"))?;
 
         if let Err(e) = download_single_license(license_id, config) {
-            eprintln!("⚠️  Failed to download {}: {}", license_id, e);
+            eprintln!(
+                "{}",
+                format!("⚠️  Failed to download {}: {}", license_id, e).red()
+            );
         }
     }
 
@@ -239,12 +247,13 @@ fn process_placeholders(
     }
 
     if placeholders.is_empty() {
-        println!("\x1b[32m✓\x1b[0m No placeholders found in license text.");
+        println!("{}", "✓ No placeholders found in license text.".green());
 
         // Warn about unused parameters when no placeholders exist
         if !placeholder_params.is_empty() {
             println!(
-                "\x1b[33m⚠\x1b[0m Warning: {} parameter(s) provided but no placeholders found:",
+                "{} {} parameter(s) provided but no placeholders found:",
+                "⚠".yellow(),
                 placeholder_params.len()
             );
             for (key, _) in placeholder_params {
@@ -255,7 +264,8 @@ fn process_placeholders(
         return Ok(license_text.to_string());
     } else if !interactive && placeholder_params.is_empty() {
         println!(
-            "\u{001b}[33m  License contains placeholders. Use --interactive or --param PLACEHOLDER=VALUE to fill them.\u{001b}[0m"
+            "{} License contains placeholders. Use --interactive or --param PLACEHOLDER=VALUE to fill them.",
+            "⚠".yellow()
         );
     }
 
@@ -317,7 +327,8 @@ fn process_placeholders(
 
     if !unused_params.is_empty() {
         println!(
-            "\x1b[33m⚠\x1b[0m Warning: {} unused parameter(s):",
+            "{} Warning: {} unused parameter(s):",
+            "⚠".yellow(),
             unused_params.len()
         );
         for param in unused_params {
@@ -329,7 +340,8 @@ fn process_placeholders(
     // Warning for unfilled placeholders
     if !unfilled_placeholders.is_empty() {
         println!(
-            "\x1b[33m⚠\x1b[0m Warning: {} placeholder(s) remain unfilled:",
+            "{} Warning: {} placeholder(s) remain unfilled:",
+            "⚠".yellow(),
             unfilled_placeholders.len()
         );
         for ph in &unfilled_placeholders {
@@ -342,12 +354,14 @@ fn process_placeholders(
     let filled_count = placeholders.len() - unfilled_placeholders.len();
     if filled_count > 0 {
         println!(
-            "\x1b[32m✓\x1b[0m Filled {} out of {} placeholder(s).",
+            "{} Filled {} out of {} placeholder(s).",
+            "✓".green(),
             filled_count,
             placeholders.len()
         );
         println!(
-            "\x1b[33m⚠ Please carefully review the license text above for any missed or incorrect placeholders.\x1b[0m"
+            "{} Please carefully review the license text above for any missed or incorrect placeholders.",
+            "⚠".yellow()
         );
     }
 

--- a/src/commands/license/list.rs
+++ b/src/commands/license/list.rs
@@ -1,3 +1,5 @@
+use colored::*;
+
 use crate::utils::cache::{Cache, CacheManager};
 use crate::utils::pattern::filter_by_wildcard;
 use crate::utils::progress;
@@ -116,7 +118,8 @@ fn list_popular_licenses(args: LicenseArgs) -> anyhow::Result<()> {
         }
 
         println!(
-            "\x1b[32m✓\x1b[0m Popular licenses matching '{}' ({} found):",
+            "{} Popular licenses matching '{}' ({} found):",
+            "✓".green(),
             search,
             matches.len()
         );
@@ -124,7 +127,7 @@ fn list_popular_licenses(args: LicenseArgs) -> anyhow::Result<()> {
 
         for (id, entry) in matches {
             if let Some(name) = entry.data.get("name").and_then(|n| n.as_str()) {
-                println!("  \x1b[32m>\x1b[0m {:<20} {}", id, name);
+                println!("  {} {:<20} {}", ">".green(), id, name);
             } else {
                 println!("{}", id);
             }
@@ -135,10 +138,10 @@ fn list_popular_licenses(args: LicenseArgs) -> anyhow::Result<()> {
 
     for (id, entry) in &cache.entries {
         if let Some(name) = entry.data.get("name").and_then(|n| n.as_str()) {
-            println!("  \x1b[32m>\x1b[0m {:<20} {}", id, name);
+            println!("  {} {:<20} {}", ">".green(), id, name);
         } else {
-            println!("  \x1b[32m>\x1b[0m {:?}", entry.data);
-            println!("  \x1b[32m>\x1b[0m {}", id);
+            println!("  {} {:<20} {:?}", ">".green(), id, entry.data);
+            println!("  {} {}", ">".green(), id);
         }
     }
 
@@ -248,7 +251,8 @@ fn list_all_licenses(args: LicenseArgs) -> anyhow::Result<()> {
     };
 
     println!(
-        "\x1b[32m✓\x1b[0m {} ({} found):",
+        "{} {} ({} found):",
+        "✓".green(),
         header,
         filtered_licenses.len()
     );
@@ -267,8 +271,11 @@ fn display_simple_licenses(licenses: &[(&str, &str, bool, &serde_json::Value)]) 
     for (id, name, is_deprecated, _) in licenses {
         let deprecated_marker = if *is_deprecated { " (deprecated)" } else { "" };
         println!(
-            "  \x1b[32m>\x1b[0m {:<20} {}{}",
-            id, name, deprecated_marker
+            "  {} {:<20} {}{}",
+            ">".green(),
+            id,
+            name,
+            deprecated_marker.yellow()
         );
     }
 }
@@ -292,11 +299,11 @@ fn list_non_software_licenses(update_cache: bool) -> anyhow::Result<()> {
     let cache: Cache<serde_json::Value> =
         ensure_spdx_license_cache(&mut cache_manager, update_cache)?;
 
-    println!("\x1b[32m✓\x1b[0m Non-Software Licenses:");
+    println!("{}", "✓ Non-Software Licenses:".green());
     println!();
 
     // Data, media, etc.
-    println!("\x1b[1mData, media, etc.\x1b[0m");
+    println!("{}", "Data, media, etc.".bold());
     for id in &["CC0-1.0", "CC-BY-4.0", "CC-BY-SA-4.0"] {
         if let Some(entry) = cache.entries.get(*id) {
             let name = entry
@@ -304,9 +311,14 @@ fn list_non_software_licenses(update_cache: bool) -> anyhow::Result<()> {
                 .get("name")
                 .and_then(|n| n.as_str())
                 .unwrap_or(id);
-            println!("  \x1b[32m>\x1b[0m {:<20} {}", id, name);
+            println!("  {} {:<20} {}", ">".green(), id, name);
         } else {
-            println!("  \x1b[31m!\x1b[0m {:<20} (not found in SPDX cache)", id);
+            println!(
+                "  {} {:<20} {}",
+                "!".red(),
+                id,
+                "(not found in SPDX cache)".yellow()
+            );
         }
     }
     println!(
@@ -314,23 +326,25 @@ fn list_non_software_licenses(update_cache: bool) -> anyhow::Result<()> {
     );
 
     // Fonts
-    println!("\x1b[1mFonts\x1b[0m");
+    println!("{}", "Fonts".bold());
     if let Some(entry) = cache.entries.get("OFL-1.1") {
         let name = entry
             .data
             .get("name")
             .and_then(|n| n.as_str())
             .unwrap_or("OFL-1.1");
-        println!("  \x1b[32m>\x1b[0m {:<20} {}\n", "OFL-1.1", name);
+        println!("  {} {:<20} {}\n", ">".green(), "OFL-1.1", name);
     } else {
         println!(
-            "   \x1b[31m!\x1b[0m {:<20} (not found in SPDX cache)",
-            "OFL-1.1"
+            "  {} {:<20} {}",
+            "!".red(),
+            "OFL-1.1",
+            "(not found in SPDX cache)".yellow()
         );
     }
 
     // Hardware
-    println!("\x1b[1mHardware\x1b[0m");
+    println!("{}", "Hardware".bold());
     for id in &["CERN-OHL-P-2.0", "CERN-OHL-W-2.0", "CERN-OHL-S-2.0"] {
         if let Some(entry) = cache.entries.get(*id) {
             let name = entry
@@ -338,9 +352,14 @@ fn list_non_software_licenses(update_cache: bool) -> anyhow::Result<()> {
                 .get("name")
                 .and_then(|n| n.as_str())
                 .unwrap_or(id);
-            println!("  \x1b[32m>\x1b[0m {:<20} {}", id, name);
+            println!("  {} {:<20} {}", ">".green(), id, name);
         } else {
-            println!("  \x1b[31m!\x1b[0m {:<20} (not found in SPDX cache)", id);
+            println!(
+                "  {} {:<20} {}",
+                "!".red(),
+                id,
+                "(not found in SPDX cache)".yellow()
+            );
         }
     }
     println!();

--- a/src/commands/license/preview.rs
+++ b/src/commands/license/preview.rs
@@ -1,7 +1,10 @@
+use colored::*;
+
 use super::{
     CHOOSEALICENSE_RAW_BASE_URL, SPDX_LICENSE_DETAILS_BASE_URL, SPDX_LICENSE_LIST_URL,
     ensure_spdx_license_cache,
 };
+
 use crate::utils::cache::{Cache, CacheManager};
 use crate::utils::remote::Fetcher;
 use serde::{Deserialize, Serialize};
@@ -62,7 +65,8 @@ impl super::Runnable for PreviewArgs {
             .unwrap_or((normalized_id.clone(), serde_json::Value::Null));
 
         println!(
-            "\x1b[36mLicense:\x1b[0m {} ({})\n",
+            "{} {} ({})\n",
+            "License:".cyan(),
             license_json
                 .get("name")
                 .and_then(|n| n.as_str())
@@ -164,7 +168,7 @@ fn show_description(
 ) -> anyhow::Result<()> {
     // Show the license description from ChooseALicense if available,
     // otherwise fallback to SPDX metadata if present.
-    println!("\x1b[36mDescription:\x1b[0m");
+    println!("{}", "Description:".cyan());
 
     // Try ChooseALicense description first
     if let Some(meta) = choosealicense_meta {
@@ -197,7 +201,7 @@ fn show_permissions(
     license_metadata: Option<&serde_json::Value>,
     choosealicense: Option<&ChooseALicenseFile>,
 ) -> anyhow::Result<()> {
-    println!("\x1b[32mPermissions:\x1b[0m");
+    println!("{}", "Permissions:".green());
     if let Some(meta) = choosealicense {
         if let Some(perms) = &meta.meta.permissions {
             for perm in perms {
@@ -230,7 +234,7 @@ fn show_limitations(
     license_metadata: Option<&serde_json::Value>,
     choosealicense: Option<&ChooseALicenseFile>,
 ) -> anyhow::Result<()> {
-    println!("\x1b[31mLimitations:\x1b[0m");
+    println!("{}", "Limitations:".red());
     if let Some(meta) = choosealicense {
         if let Some(lims) = &meta.meta.limitations {
             for lim in lims {
@@ -263,7 +267,7 @@ fn show_conditions(
     license_metadata: Option<&serde_json::Value>,
     choosealicense: Option<&ChooseALicenseFile>,
 ) -> anyhow::Result<()> {
-    println!("\x1b[33mConditions:\x1b[0m");
+    println!("{}", "Conditions:".yellow());
     if let Some(meta) = choosealicense {
         if let Some(conds) = &meta.meta.conditions {
             for cond in conds {
@@ -293,7 +297,7 @@ fn show_conditions(
 }
 
 fn show_spdx_metadata(license_metadata: &serde_json::Value) -> anyhow::Result<()> {
-    println!("\x1b[36mSPDX Metadata:\x1b[0m");
+    println!("{}", "SPDX Metadata:".cyan());
 
     if let Some(license_id) = license_metadata.get("licenseId").and_then(|id| id.as_str()) {
         println!("  License ID: {}", license_id);
@@ -318,9 +322,9 @@ fn show_spdx_metadata(license_metadata: &serde_json::Value) -> anyhow::Result<()
         .and_then(|d| d.as_bool())
     {
         if deprecated {
-            println!("  \x1b[33mStatus: DEPRECATED\x1b[0m");
+            println!("  {}", "Status: DEPRECATED".yellow());
             if let Some(details_url) = license_metadata.get("detailsUrl").and_then(|d| d.as_str()) {
-                println!("      \x1b[33mSee details: {}\x1b[0m", details_url);
+                println!("      {}", format!("See details: {}", details_url).yellow());
             }
         }
     }
@@ -331,7 +335,7 @@ fn show_spdx_metadata(license_metadata: &serde_json::Value) -> anyhow::Result<()
 fn show_full_license(url: &str) -> anyhow::Result<()> {
     let fetcher = Fetcher::new();
 
-    println!("\x1b[36mLicense Text:\x1b[0m");
+    println!("{}", "License Text:".cyan());
     println!("{}", "─".repeat(80));
 
     match fetcher.fetch_json(url) {

--- a/src/commands/pr/add.rs
+++ b/src/commands/pr/add.rs
@@ -1,3 +1,4 @@
+use colored::*;
 use std::path::{Path, PathBuf};
 
 use crate::utils::file;
@@ -71,8 +72,10 @@ fn download_all_templates(dir_path: Option<&PathBuf>, force: bool) -> anyhow::Re
 
         if let Err(e) = download_single_template(template_name, dir_path, force) {
             eprintln!(
-                "\x1b[31m✗\x1b[0m Failed to add template '{}': {}",
-                template_name, e
+                "{} Failed to add template '{}': {}",
+                "✗".red(),
+                template_name,
+                e
             );
             errors.push((template_name.to_string(), e));
         }
@@ -85,11 +88,15 @@ fn download_all_templates(dir_path: Option<&PathBuf>, force: bool) -> anyhow::Re
 
     if errors.is_empty() {
         println!(
-            "\x1b[32m✓\x1b[0m Downloaded all pull request templates to {}",
+            "{} Downloaded all pull request templates to {}",
+            "✓".green(),
             output_location
         );
     } else {
-        println!("\x1b[33m⚠\x1b[0m Some templates failed to download. See errors above.");
+        println!(
+            "{} Some templates failed to download. See errors above.",
+            "⚠".yellow()
+        );
     }
 
     Ok(())
@@ -120,7 +127,7 @@ fn download_single_template(
 
     file::save_file(&content, &dest_path, force)?;
 
-    println!("\x1b[32m✓\x1b[0m {} - has beed added.", dest_path.display());
+    println!("{} {} - has been added.", "✓".green(), dest_path.display());
 
     Ok(())
 }

--- a/src/commands/pr/list.rs
+++ b/src/commands/pr/list.rs
@@ -1,3 +1,5 @@
+use colored::*;
+
 use crate::utils::get_comment;
 use crate::utils::manifest_navigator::ManifestNavigator;
 use crate::utils::remote::Fetcher;
@@ -25,7 +27,7 @@ fn list_all_pr_templates() -> anyhow::Result<()> {
     if template_entries.is_empty() {
         println!("No pull request templates found.");
     } else {
-        println!("\x1b[32m✓\x1b[0m Available pull request templates:");
+        println!("{} Available pull request templates:", "✓".green());
         for entry in template_entries {
             let file_url = &entry.full_url;
             let extension = std::path::Path::new(file_url)
@@ -42,7 +44,7 @@ fn list_all_pr_templates() -> anyhow::Result<()> {
 
             match comment {
                 Some(description) => {
-                    println!("  \x1b[32m>\x1b[0m {:<12} - {}", entry.name, description)
+                    println!("  {} {:<12} - {}", ">".green(), entry.name, description)
                 }
                 None => println!("  {}", entry.name),
             }


### PR DESCRIPTION
## 🔗 Related Issue(s)
<!-- > Link to the relevant issue(s). Create one if it doesn't exist. -->

- Closes #73 

---

## Summary

<!-- Briefly describe **what** this PR changes and **why**. -->
- replaced color encodings to use `colored` rust lib, to ensure uniform behaviour across devices that may not support it.

<!-- Example:
> Added input validation to the registration form to improve user experience and prevent invalid data submission. -->

---

## Testing

How was this change tested? List test cases, manual steps, or CI checks.

- [ ] Added/updated unit tests
- [x] Performed manual testing
- [ ] Validated with stakeholders
