### PR TITLE
Docs/add labels guide

### DIFF
--- a/docs/docs/commands/issue/issue.md
+++ b/docs/docs/commands/issue/issue.md
@@ -99,11 +99,11 @@ By default, issue templates are saved to the `.github/ISSUE_TEMPLATE/` directory
 - [List Issue Templates](./issue-list.md)
 - [Preview Issue Templates](./issue-preview.md)
 
-Adding Labels to Your Repository
+## Adding Labels to Your Repository
 
 To ensure your repository uses the same labels as GitForge, follow these steps:
 
-1. Copy Labels from GitForge
+### 1. Copy Labels from GitForge
 You can export labels from GitForge using the `gh label clone` command (requires the GitHub CLI):
 
 ```bash
@@ -113,10 +113,10 @@ gh label clone RafaelJohn9/gitforge --repo <your-username>/<your-repo>
 
 This will duplicate all labels (like bug, feature, chore, documentation, etc.) into your repository.
 
-2. Verify Labels
+### 2. Verify Labels
 
 After cloning, check your repo’s Issues > Labels section on GitHub to confirm they match GitForge’s label set.
 
-3. Maintain Consistency
+### 3. Maintain Consistency
 
 Whenever GitForge updates its label set, rerun the clone command to sync updates.


### PR DESCRIPTION
## Description

This PR updates the documentation to include a new section on **adding GitForge labels to user repositories**.  
It provides clear, step-by-step instructions on how to clone and sync labels from GitForge using the GitHub CLI.  
#150 

**Fixes:** N/A

---

## Type of Change

- [x] Documentation update (adds new content and improves clarity)

---

## How Has This Been Tested?

- Verified that the Markdown renders correctly on GitHub.  
- Checked command syntax to ensure compatibility with the GitHub CLI.  
- Confirmed that cloned labels appear correctly under *Issues → Labels* in a test repository.

---

## Checklist

- [x] My code follows the project's coding style guidelines  
- [x] I have performed a self-review of my own code  
- [x] My changes generate no new warnings or errors  
- [x] I have made corresponding changes to the documentation  
- [x] New and existing unit tests pass locally with my changes  

---

## Screenshots (if applicable)

*Not applicable – documentation-only change.*

---

## Additional Context

This addition improves user experience by helping maintain **consistent label structures** across repositories that integrate with GitForge.  
Future updates can include automation via a GitHub Action to sync labels periodically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on adding labels to your repository, including steps to clone GitForge labels, verify them in GitHub, and maintain synchronization with GitForge updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->